### PR TITLE
fix: handle unbound DRY_RUN variable in home-manager activation

### DIFF
--- a/home/fonts.nix
+++ b/home/fonts.nix
@@ -74,7 +74,7 @@ in
       $DRY_RUN_CMD ${pkgs.fontconfig}/bin/fc-cache -f $VERBOSE_ARG || true
       
       # Verify Nerd Fonts are available
-      if [ -z "$DRY_RUN" ]; then
+      if [ -z "''${DRY_RUN:-}" ]; then
         echo "Checking for Nerd Font installation..."
         if ${pkgs.fontconfig}/bin/fc-list | ${pkgs.gnugrep}/bin/grep -q "Nerd Font"; then
           echo "✓ Nerd Fonts successfully installed"


### PR DESCRIPTION
## Summary
- Fixed home-manager activation script error caused by unbound DRY_RUN variable
- Added default empty value using parameter expansion to prevent the error

## Problem
When running `home-manager switch --flake .#mabroor`, the activation was failing with:
```
/tmp/home-manager-build.LX21Cjq0pK/generation/activate: line 367: DRY_RUN: unbound variable
```

## Solution
Changed the conditional check from `[ -z "$DRY_RUN" ]` to `[ -z "${DRY_RUN:-}" ]` to provide a default empty value when the variable is unset.

## Test plan
- [x] Run `home-manager switch --flake .#mabroor` and verify it completes without errors
- [x] Verify font cache refresh still works correctly
- [x] Confirm Nerd Font installation check runs as expected

🤖 Generated with [Claude Code](https://claude.ai/code)